### PR TITLE
🛠️ Fix CR feedback and update install.yml schema

### DIFF
--- a/.claude/skills/yml-installer/SKILL.md
+++ b/.claude/skills/yml-installer/SKILL.md
@@ -4,7 +4,7 @@ description: Create install.yml manifest for packages installable via spm. Suppo
 user-invocable: true
 argument-hint: "<path> [-y]"
 license: MIT
-compatibility: "Claude Code CLI"
+compatibility: "Any AI coding assistant that supports skills (Claude Code, Open Code, etc.)"
 metadata:
   author: supa-magic
   version: 1.0.0
@@ -25,7 +25,7 @@ Create a universal `install.yml` manifest for any package type.
 
 | Argument | Format | Default | Effect |
 |----------|--------|---------|--------|
-| `path` | Positional (1st) | — | Path to the folder where install.yml will be created (name derived from folder) |
+| `path` | Positional (1st) | — | Path to the folder where install.yml will be created |
 | `-y`, `--yes` | Flag | `false` | Skip all confirmation gates |
 
 ## Instructions

--- a/.claude/skills/yml-installer/SKILL.md
+++ b/.claude/skills/yml-installer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: yml-installer
-description: Create install.yml manifest for packages installable via spm. Supports skills, skillsets, agents, hooks, MCP, memory, and rules. Use when developer wants to create an install manifest, or says "new install", "create install.yml".
+description: Create install.yml manifest for packages installable via spm. Supports skills, agents, hooks, and rules. Use when developer wants to create an install manifest, or says "new install", "create install.yml".
 user-invocable: true
 argument-hint: "<path> [-y]"
 license: MIT

--- a/.claude/skills/yml-installer/SKILL.md
+++ b/.claude/skills/yml-installer/SKILL.md
@@ -4,7 +4,7 @@ description: Create install.yml manifest for packages installable via spm. Suppo
 user-invocable: true
 argument-hint: "<path> [-y]"
 license: MIT
-compatibility: "Any AI coding assistant that supports skills (Claude Code, Open Code, etc.)"
+compatibility: "Any AI coding assistant that supports skills (Claude Code, OpenCode, etc.)"
 metadata:
   author: supa-magic
   version: 1.0.0

--- a/skills/sounds/retro-game/SETUP.md
+++ b/skills/sounds/retro-game/SETUP.md
@@ -33,7 +33,7 @@ node player.mjs error
 
 ## Claude Code
 
-**Config file**: `~/.claude/settings.json` (user-level) or `.claude/settings.json` (project-level)
+**Config file**: `.claude/settings.json` (project-level)
 
 ```json
 {
@@ -43,7 +43,7 @@ node player.mjs error
         "hooks": [
           {
             "type": "command",
-            "command": "node /absolute/path/to/player.mjs complete"
+            "command": "node .spm/retro-game-sounds/player.mjs complete"
           }
         ]
       }
@@ -53,7 +53,7 @@ node player.mjs error
         "hooks": [
           {
             "type": "command",
-            "command": "node /absolute/path/to/player.mjs attention"
+            "command": "node .spm/retro-game-sounds/player.mjs attention"
           }
         ]
       }
@@ -63,7 +63,7 @@ node player.mjs error
         "hooks": [
           {
             "type": "command",
-            "command": "node /absolute/path/to/player.mjs error"
+            "command": "node .spm/retro-game-sounds/player.mjs error"
           }
         ]
       }
@@ -73,7 +73,7 @@ node player.mjs error
         "hooks": [
           {
             "type": "command",
-            "command": "node /absolute/path/to/player.mjs subagent-complete"
+            "command": "node .spm/retro-game-sounds/player.mjs subagent-complete"
           }
         ]
       }
@@ -83,7 +83,7 @@ node player.mjs error
         "hooks": [
           {
             "type": "command",
-            "command": "node /absolute/path/to/player.mjs compacted"
+            "command": "node .spm/retro-game-sounds/player.mjs compacted"
           }
         ]
       }
@@ -98,7 +98,7 @@ node player.mjs error
 
 ## Cursor
 
-**Config file**: `.cursor/hooks.json` (project-level) or `~/.cursor/hooks.json` (user-level)
+**Config file**: `.cursor/hooks.json` (project-level)
 
 ```json
 {
@@ -106,12 +106,12 @@ node player.mjs error
   "hooks": {
     "stop": [
       {
-        "command": "node /absolute/path/to/player.mjs complete"
+        "command": "node .spm/retro-game-sounds/player.mjs complete"
       }
     ],
     "afterFileEdit": [
       {
-        "command": "node /absolute/path/to/player.mjs attention"
+        "command": "node .spm/retro-game-sounds/player.mjs attention"
       }
     ]
   }
@@ -124,26 +124,26 @@ node player.mjs error
 
 ## Windsurf
 
-**Config file**: `.windsurf/hooks.json` (workspace) or `~/.codeium/windsurf/hooks.json` (user-level)
+**Config file**: `.windsurf/hooks.json` (project-level)
 
 ```json
 {
   "hooks": {
     "post_cascade_response": [
       {
-        "command": "node /absolute/path/to/player.mjs complete",
+        "command": "node .spm/retro-game-sounds/player.mjs complete",
         "show_output": false
       }
     ],
     "pre_user_prompt": [
       {
-        "command": "node /absolute/path/to/player.mjs attention",
+        "command": "node .spm/retro-game-sounds/player.mjs attention",
         "show_output": false
       }
     ],
     "post_run_command": [
       {
-        "command": "node /absolute/path/to/player.mjs complete",
+        "command": "node .spm/retro-game-sounds/player.mjs complete",
         "show_output": false
       }
     ]
@@ -157,27 +157,27 @@ node player.mjs error
 
 ## Cline
 
-**Config location**: `~/Documents/Cline/Hooks/` (macOS/Linux) or `.clinerules/hooks/` (project-level)
+**Config location**: `.clinerules/hooks/` (project-level)
 
 Create one file per event (filename = event name, no extension):
 
-**`~/Documents/Cline/Hooks/TaskComplete`**:
+**`.clinerules/hooks/TaskComplete`**:
 ```bash
 #!/usr/bin/env bash
-node /absolute/path/to/player.mjs complete
+node .spm/retro-game-sounds/player.mjs complete
 echo '{"cancel": false}'
 ```
 
-**`~/Documents/Cline/Hooks/PreCompact`**:
+**`.clinerules/hooks/PreCompact`**:
 ```bash
 #!/usr/bin/env bash
-node /absolute/path/to/player.mjs compacted
+node .spm/retro-game-sounds/player.mjs compacted
 echo '{"cancel": false}'
 ```
 
 Make scripts executable:
 ```bash
-chmod +x ~/Documents/Cline/Hooks/*
+chmod +x .clinerules/hooks/*
 ```
 
 > Cline supports: `TaskStart`, `TaskResume`, `TaskCancel`, `TaskComplete`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `PreCompact`.
@@ -186,20 +186,20 @@ chmod +x ~/Documents/Cline/Hooks/*
 
 ## OpenCode
 
-**Config location**: `.opencode/plugins/` (project-level) or `~/.config/opencode/plugins/` (global)
+**Config location**: `.opencode/plugins/` (project-level)
 
 **`.opencode/plugins/retro-sounds.mjs`**:
 ```javascript
 export default async ({ $ }) => ({
   hooks: {
     "session.idle": async () => {
-      await $`node /absolute/path/to/player.mjs attention`
+      await $`node .spm/retro-game-sounds/player.mjs attention`
     },
     "session.compacted": async () => {
-      await $`node /absolute/path/to/player.mjs compacted`
+      await $`node .spm/retro-game-sounds/player.mjs compacted`
     },
     "session.error": async () => {
-      await $`node /absolute/path/to/player.mjs error`
+      await $`node .spm/retro-game-sounds/player.mjs error`
     },
   },
 })
@@ -214,4 +214,4 @@ export default async ({ $ }) => ({
 - **No sound on Linux**: Install `alsa-utils` (`sudo apt install alsa-utils`)
 - **No sound on macOS**: `afplay` is built-in, check system volume
 - **No sound on Windows**: PowerShell `Media.SoundPlayer` is built-in, check system volume
-- **Path**: Replace `/absolute/path/to/player.mjs` with `~/.spm/retro-game/player.mjs` (default install location)
+- **Path**: Default install location is `.spm/retro-game-sounds/player.mjs` (project-level)

--- a/skills/sounds/retro-game/SETUP.md
+++ b/skills/sounds/retro-game/SETUP.md
@@ -24,9 +24,9 @@ Supported tools: **Claude Code**, **Cursor**, **Windsurf**, **Cline**, **OpenCod
 Run manually to verify sounds work on your system:
 
 ```bash
-node play.mjs complete
-node play.mjs attention
-node play.mjs error
+node player.mjs complete
+node player.mjs attention
+node player.mjs error
 ```
 
 ---
@@ -43,7 +43,7 @@ node play.mjs error
         "hooks": [
           {
             "type": "command",
-            "command": "node /absolute/path/to/play.mjs complete"
+            "command": "node /absolute/path/to/player.mjs complete"
           }
         ]
       }
@@ -53,7 +53,7 @@ node play.mjs error
         "hooks": [
           {
             "type": "command",
-            "command": "node /absolute/path/to/play.mjs attention"
+            "command": "node /absolute/path/to/player.mjs attention"
           }
         ]
       }
@@ -63,7 +63,7 @@ node play.mjs error
         "hooks": [
           {
             "type": "command",
-            "command": "node /absolute/path/to/play.mjs error"
+            "command": "node /absolute/path/to/player.mjs error"
           }
         ]
       }
@@ -73,7 +73,7 @@ node play.mjs error
         "hooks": [
           {
             "type": "command",
-            "command": "node /absolute/path/to/play.mjs subagent-complete"
+            "command": "node /absolute/path/to/player.mjs subagent-complete"
           }
         ]
       }
@@ -83,7 +83,7 @@ node play.mjs error
         "hooks": [
           {
             "type": "command",
-            "command": "node /absolute/path/to/play.mjs compacted"
+            "command": "node /absolute/path/to/player.mjs compacted"
           }
         ]
       }
@@ -106,12 +106,12 @@ node play.mjs error
   "hooks": {
     "stop": [
       {
-        "command": "node /absolute/path/to/play.mjs complete"
+        "command": "node /absolute/path/to/player.mjs complete"
       }
     ],
     "afterFileEdit": [
       {
-        "command": "node /absolute/path/to/play.mjs attention"
+        "command": "node /absolute/path/to/player.mjs attention"
       }
     ]
   }
@@ -131,19 +131,19 @@ node play.mjs error
   "hooks": {
     "post_cascade_response": [
       {
-        "command": "node /absolute/path/to/play.mjs complete",
+        "command": "node /absolute/path/to/player.mjs complete",
         "show_output": false
       }
     ],
     "pre_user_prompt": [
       {
-        "command": "node /absolute/path/to/play.mjs attention",
+        "command": "node /absolute/path/to/player.mjs attention",
         "show_output": false
       }
     ],
     "post_run_command": [
       {
-        "command": "node /absolute/path/to/play.mjs complete",
+        "command": "node /absolute/path/to/player.mjs complete",
         "show_output": false
       }
     ]
@@ -164,14 +164,14 @@ Create one file per event (filename = event name, no extension):
 **`~/Documents/Cline/Hooks/TaskComplete`**:
 ```bash
 #!/usr/bin/env bash
-node /absolute/path/to/play.mjs complete
+node /absolute/path/to/player.mjs complete
 echo '{"cancel": false}'
 ```
 
 **`~/Documents/Cline/Hooks/PreCompact`**:
 ```bash
 #!/usr/bin/env bash
-node /absolute/path/to/play.mjs compacted
+node /absolute/path/to/player.mjs compacted
 echo '{"cancel": false}'
 ```
 
@@ -193,13 +193,13 @@ chmod +x ~/Documents/Cline/Hooks/*
 export default async ({ $ }) => ({
   hooks: {
     "session.idle": async () => {
-      await $`node /absolute/path/to/play.mjs complete`
+      await $`node /absolute/path/to/player.mjs attention`
     },
     "session.compacted": async () => {
-      await $`node /absolute/path/to/play.mjs compacted`
+      await $`node /absolute/path/to/player.mjs compacted`
     },
     "session.error": async () => {
-      await $`node /absolute/path/to/play.mjs error`
+      await $`node /absolute/path/to/player.mjs error`
     },
   },
 })
@@ -214,4 +214,4 @@ export default async ({ $ }) => ({
 - **No sound on Linux**: Install `alsa-utils` (`sudo apt install alsa-utils`)
 - **No sound on macOS**: `afplay` is built-in, check system volume
 - **No sound on Windows**: PowerShell `Media.SoundPlayer` is built-in, check system volume
-- **Path**: Replace `/absolute/path/to/play.mjs` with `~/.spm/retro-game/play.mjs` (default install location)
+- **Path**: Replace `/absolute/path/to/player.mjs` with `~/.spm/retro-game/player.mjs` (default install location)

--- a/skills/sounds/retro-game/install.yml
+++ b/skills/sounds/retro-game/install.yml
@@ -1,6 +1,6 @@
 name: retro-game-sounds
 version: 1.0.0
-description: "Retro game sound effects for AI coding assistant hook events"
+description: "Retro game sound effects that help track AI coding assistant state via hook events"
 license: MIT
 compatibility:
   - Claude Code
@@ -9,12 +9,14 @@ requires:
 
 hooks:
   retro-game-sounds:
-    - player.mjs
-    - attention.wav
-    - compacted.wav
-    - complete.wav
-    - error.wav
-    - permission.wav
-    - subagent-complete.wav
+    source: ./
+    files:
+      - player.mjs
+      - attention.wav
+      - compacted.wav
+      - complete.wav
+      - error.wav
+      - permission.wav
+      - subagent-complete.wav
 
 setup: SETUP.md

--- a/skills/sounds/retro-game/player.mjs
+++ b/skills/sounds/retro-game/player.mjs
@@ -9,7 +9,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const sound = process.argv[2]
 
 if (!sound) {
-  console.error("Usage: node play.mjs <sound-name>")
+  console.error("Usage: node player.mjs <sound-name>")
+  process.exit(1)
+}
+
+if (!/^[a-z0-9-]+$/.test(sound)) {
+  console.error("Invalid sound name — only lowercase letters, digits, and hyphens allowed")
   process.exit(1)
 }
 

--- a/skills/yml-installer/SKILL.md
+++ b/skills/yml-installer/SKILL.md
@@ -88,12 +88,14 @@ Ask:
 >
 > For each hook, provide:
 > - **Name** — hook name (e.g., `retro-game-sounds`, `pre-commit`)
+> - **Source** — relative to `install.yml` (use `./` for local) or full path/URL for external
 > - **Files** — list of files to include
 >
 > Enter hooks one at a time, or paste multiple. Type **done** when finished.
 
 Collect entries in a loop. For each entry, parse:
 - `name`: kebab-case key
+- `source`: relative path (default `./`) or full path/URL for external
 - `files`: list of file paths
 
 Keep collecting until the developer types "done" or equivalent.
@@ -116,12 +118,14 @@ Ask:
 >
 > For each skill, provide:
 > - **Alias** — short name (e.g., `git`, `testing`)
+> - **Source** — relative to `install.yml` (use `./` for local) or full path/URL for external
 > - **Files** — list of files to include (e.g., `SKILL.md`, `references/command.md`)
 >
 > Enter skills one at a time, or paste multiple. Type **done** when finished.
 
 Collect entries in a loop. For each entry, parse:
 - `alias`: kebab-case key
+- `source`: relative path (default `./`) or full path/URL for external
 - `files`: list of file paths
 
 Keep collecting until the developer types "done" or equivalent.
@@ -160,16 +164,20 @@ agents:
 
 hooks:
   <name>:
-    - <file1>
-    - <file2>
+    source: <./ or full-path/url>
+    files:
+      - <file1>
+      - <file2>
 
 rules:
   - <file>
 
 skills:
   <alias>:
-    - <file1>
-    - <file2>
+    source: <./ or full-path/url>
+    files:
+      - <file1>
+      - <file2>
 
 setup: SETUP.md
 ```
@@ -240,7 +248,7 @@ Actions:
 2. Ask for description → "Retro game sound effects for AI coding assistant hooks"
 3. Collect metadata → license: MIT, compatibility: Claude Code CLI, node@18
 4. Collect agents → skip
-5. Collect hooks → `retro-game-sounds`: `player.mjs`, `attention.wav`, `complete.wav`, `error.wav`
+5. Collect hooks → `retro-game-sounds`: source=`./`, files=`player.mjs`, `attention.wav`, `complete.wav`, `error.wav`
 6. Collect rules → skip
 7. Collect skills → skip
 8. Setup → yes
@@ -259,10 +267,12 @@ compatibility:
 
 hooks:
   retro-game-sounds:
-    - player.mjs
-    - attention.wav
-    - complete.wav
-    - error.wav
+    source: ./
+    files:
+      - player.mjs
+      - attention.wav
+      - complete.wav
+      - error.wav
 
 setup: SETUP.md
 ```
@@ -278,7 +288,7 @@ Actions:
 4. Collect agents → skip
 5. Collect hooks → skip
 6. Collect rules → `fsd-architecture.md`
-7. Collect skills → `git`: `SKILL.md`, `commit.md`, `branch.md`
+7. Collect skills → `git`: source=`./`, files=`SKILL.md`, `commit.md`, `branch.md`
 8. Setup → yes
 9. Generate files, skip confirmations
 10. Write files
@@ -294,9 +304,11 @@ rules:
 
 skills:
   git:
-    - SKILL.md
-    - commit.md
-    - branch.md
+    source: ./
+    files:
+      - SKILL.md
+      - commit.md
+      - branch.md
 
 setup: SETUP.md
 ```

--- a/skills/yml-installer/SKILL.md
+++ b/skills/yml-installer/SKILL.md
@@ -240,7 +240,7 @@ Actions:
 2. Ask for description → "Retro game sound effects for AI coding assistant hooks"
 3. Collect metadata → license: MIT, compatibility: Claude Code CLI, node@18
 4. Collect agents → skip
-5. Collect hooks → `retro-game-sounds`: `play.mjs`, `attention.wav`, `complete.wav`, `error.wav`
+5. Collect hooks → `retro-game-sounds`: `player.mjs`, `attention.wav`, `complete.wav`, `error.wav`
 6. Collect rules → skip
 7. Collect skills → skip
 8. Setup → yes
@@ -259,7 +259,7 @@ compatibility:
 
 hooks:
   retro-game-sounds:
-    - play.mjs
+    - player.mjs
     - attention.wav
     - complete.wav
     - error.wav

--- a/skills/yml-installer/SKILL.md
+++ b/skills/yml-installer/SKILL.md
@@ -4,7 +4,7 @@ description: Create install.yml manifest for packages installable via spm. Suppo
 user-invocable: true
 argument-hint: "<path> [-y]"
 license: MIT
-compatibility: "Any AI coding assistant that supports skills (Claude Code, Open Code, etc.)"
+compatibility: "Any AI coding assistant that supports skills (Claude Code, OpenCode, etc.)"
 metadata:
   author: supa-magic
   version: 1.0.0

--- a/skills/yml-installer/assets/install-template.yml
+++ b/skills/yml-installer/assets/install-template.yml
@@ -21,7 +21,7 @@ hooks: {}
 #      - complete.wav
 
 rules: []
-#  - https://github.com/awesome-claude-skills/fe/architecture.md
+#  - architecture.md
 
 skills: {}
 #  git:

--- a/skills/yml-installer/assets/install-template.yml
+++ b/skills/yml-installer/assets/install-template.yml
@@ -10,6 +10,7 @@ requires: []
 #  - gh
 
 agents: []
+#  - https://github.com/awesome-skills/fe/test-writer.md
 #  - code-reviewer.md
 
 hooks: {}
@@ -21,11 +22,12 @@ hooks: {}
 #      - complete.wav
 
 rules: []
-#  - architecture.md
+#  - ./code-style.md
+#  - https://github.com/awesome-skills/fe/architecture.md
 
 skills: {}
 #  git:
-#    source: ./
+#    source: https://github.com/awesome-skills/git
 #    files:
 #      - SKILL.md
 #      - references/command.md

--- a/skills/yml-installer/assets/install-template.yml
+++ b/skills/yml-installer/assets/install-template.yml
@@ -14,16 +14,20 @@ agents: []
 
 hooks: {}
 #  retro-game-sounds:
-#    - play.mjs
-#    - attention.wav
-#    - complete.wav
+#    source: ./skills/sounds/retro-game
+#    files:
+#      - waves/attention.wav
+#      - waves/complete.wav
+#      - player.mjs
 
 rules: []
-#  - architecture.md
+#  - https://github.com/awesome-claude-skills/fe/architecture.md
 
 skills: {}
 #  git:
-#    - SKILL.md
-#    - references/command.md
+#    source: https://github.com/composio-hq/awesome-claude-skills/lint
+#    files:
+#      - SKILL.md
+#      - references/command.md
 
 setup: # SETUP.md

--- a/skills/yml-installer/assets/install-template.yml
+++ b/skills/yml-installer/assets/install-template.yml
@@ -14,18 +14,18 @@ agents: []
 
 hooks: {}
 #  retro-game-sounds:
-#    source: ./skills/sounds/retro-game
+#    source: ./
 #    files:
-#      - waves/attention.wav
-#      - waves/complete.wav
 #      - player.mjs
+#      - attention.wav
+#      - complete.wav
 
 rules: []
 #  - https://github.com/awesome-claude-skills/fe/architecture.md
 
 skills: {}
 #  git:
-#    source: https://github.com/composio-hq/awesome-claude-skills/lint
+#    source: ./
 #    files:
 #      - SKILL.md
 #      - references/command.md

--- a/skills/yml-installer/references/install-schema.md
+++ b/skills/yml-installer/references/install-schema.md
@@ -35,7 +35,7 @@ Map of hook entries. Each key is a hook name, each value is a list of files to i
 ```yaml
 hooks:
   retro-game-sounds:
-    - play.mjs
+    - player.mjs
     - attention.wav
     - complete.wav
 ```
@@ -88,7 +88,7 @@ compatibility:
 
 hooks:
   retro-game-sounds:
-    - play.mjs
+    - player.mjs
     - attention.wav
     - compacted.wav
     - complete.wav

--- a/skills/yml-installer/references/install-schema.md
+++ b/skills/yml-installer/references/install-schema.md
@@ -30,14 +30,16 @@ agents:
 
 ### hooks
 
-Map of hook entries. Each key is a hook name, each value is a list of files to include.
+Map of hook entries. Each key is a hook name, with `source` (relative to `install.yml` or full path/URL for external sources) and `files` (list of files to include). Use `./` when files live alongside `install.yml`.
 
 ```yaml
 hooks:
   retro-game-sounds:
-    - player.mjs
-    - attention.wav
-    - complete.wav
+    source: ./
+    files:
+      - player.mjs
+      - attention.wav
+      - complete.wav
 ```
 
 ### rules
@@ -52,13 +54,15 @@ rules:
 
 ### skills
 
-Map of skill entries. Each key is a skill alias, each value is a list of files to include.
+Map of skill entries. Each key is a skill alias, with `source` (relative to `install.yml` or full path/URL for external sources) and `files` (list of files to include). Use `./` when files live alongside `install.yml`.
 
 ```yaml
 skills:
   git:
-    - SKILL.md
-    - references/command.md
+    source: ./
+    files:
+      - SKILL.md
+      - references/command.md
 ```
 
 ## Validation Rules
@@ -69,7 +73,7 @@ skills:
 4. `license` must be a valid SPDX identifier if present
 5. `compatibility` must be a list of strings if present
 6. `requires` must be a list of strings in `tool` or `tool@version` format if present
-7. `hooks` and `skills` entries must be maps of name → file list
+7. `hooks` and `skills` entries must be maps of name → `{ source, files }` object
 8. All file paths must be relative (no leading `/`)
 9. Omit empty sections entirely (don't write `agents: []` or `skills: {}`)
 
@@ -88,12 +92,14 @@ compatibility:
 
 hooks:
   retro-game-sounds:
-    - player.mjs
-    - attention.wav
-    - compacted.wav
-    - complete.wav
-    - error.wav
-    - subagent-complete.wav
+    source: ./
+    files:
+      - player.mjs
+      - attention.wav
+      - compacted.wav
+      - complete.wav
+      - error.wav
+      - subagent-complete.wav
 
 setup: SETUP.md
 ```
@@ -111,9 +117,11 @@ rules:
 
 skills:
   git:
-    - SKILL.md
-    - commit.md
-    - branch.md
+    source: ./
+    files:
+      - SKILL.md
+      - commit.md
+      - branch.md
 
 setup: SETUP.md
 ```
@@ -138,17 +146,23 @@ agents:
 
 hooks:
   pre-commit:
-    - lint-check.sh
+    source: ./
+    files:
+      - lint-check.sh
 
 rules:
   - architecture.md
 
 skills:
   git:
-    - SKILL.md
-    - commit.md
+    source: https://github.com/example/skills/git
+    files:
+      - SKILL.md
+      - commit.md
   testing:
-    - SKILL.md
+    source: ./
+    files:
+      - SKILL.md
 
 setup: SETUP.md
 ```

--- a/skills/yml-installer/references/install-schema.md
+++ b/skills/yml-installer/references/install-schema.md
@@ -74,7 +74,7 @@ skills:
 5. `compatibility` must be a list of strings if present
 6. `requires` must be a list of strings in `tool` or `tool@version` format if present
 7. `hooks` and `skills` entries must be maps of name → `{ source, files }` object
-8. All file paths must be relative (no leading `/`)
+8. All `files` entries and path lists (agents, rules) must be relative (no leading `/`); `source` may be a relative path or full URL
 9. Omit empty sections entirely (don't write `agents: []` or `skills: {}`)
 
 ## Examples

--- a/skills/yml-installer/references/install-schema.md
+++ b/skills/yml-installer/references/install-schema.md
@@ -20,12 +20,12 @@ Include only non-empty sections. Omit sections with no entries. Sections are lis
 
 ### agents
 
-List of agent definition files (relative to `install.yml`).
+List of agent definition files. Paths can be relative to `install.yml` or full URLs for external sources.
 
 ```yaml
 agents:
   - code-reviewer.md
-  - pr-summarizer.md
+  - https://github.com/awesome-skills/fe/test-writer.md
 ```
 
 ### hooks
@@ -44,12 +44,12 @@ hooks:
 
 ### rules
 
-List of rule files (relative to `install.yml`).
+List of rule files. Paths can be relative to `install.yml` or full URLs for external sources.
 
 ```yaml
 rules:
-  - architecture.md
-  - naming-conventions.md
+  - ./code-style.md
+  - https://github.com/awesome-skills/fe/architecture.md
 ```
 
 ### skills
@@ -74,7 +74,7 @@ skills:
 5. `compatibility` must be a list of strings if present
 6. `requires` must be a list of strings in `tool` or `tool@version` format if present
 7. `hooks` and `skills` entries must be maps of name → `{ source, files }` object
-8. All `files` entries and path lists (agents, rules) must be relative (no leading `/`); `source` may be a relative path or full URL
+8. All paths (agents, rules, files, source) can be relative to `install.yml` or full URLs for external sources
 9. Omit empty sections entirely (don't write `agents: []` or `skills: {}`)
 
 ## Examples
@@ -142,6 +142,7 @@ requires:
   - jq
 
 agents:
+  - https://github.com/awesome-skills/fe/test-writer.md
   - code-reviewer.md
 
 hooks:
@@ -151,7 +152,8 @@ hooks:
       - lint-check.sh
 
 rules:
-  - architecture.md
+  - ./architecture.md
+  - https://github.com/awesome-skills/fe/naming-conventions.md
 
 skills:
   git:


### PR DESCRIPTION
## Description

Follow-up to PR #15. Addresses Copilot code review feedback and introduces the `source` + `files` structure for hooks and skills in the install.yml schema.

- Fix `play.mjs` → `player.mjs` filename inconsistencies across all docs
- Fix OpenCode idle mapping to play `attention.wav` instead of `complete.wav`
- Add input sanitization to `player.mjs` against path traversal
- Align skill description with actually supported sections
- Introduce `source` + `files` structure for hooks/skills in schema, template, SKILL.md, and examples
- Update SETUP.md to use project-level config paths (`.spm/retro-game-sounds/`)
- Sync `.claude/skills/yml-installer/SKILL.md` binding with main skill metadata

## Type of change

- Bug fix (fix) (non-breaking change which fixes an issue)

## Related Issues

- Closes #13

## Notes

- All 10 Copilot review threads from PR #15 replied to and resolved (8 fixed, 2 skipped)
- `source: ./` means files are relative to `install.yml`; full path/URL for external sources

## Check list

- [x] I have performed a self-review of my code
- [x] My code follows the project's coding style and conventions
- [x] I have updated the documentation (if applicable)